### PR TITLE
Twitter連携を実装

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -2,4 +2,5 @@ RAILS_ENV=production
 SENDGRID_USERNAME=username
 SENDGRID_PASSWORD=password
 GA_TRACKINGID=UA-xxxxxxxx-x
+FACEBOOK_SECURET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 TWITTER_SECURET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/.env.sample
+++ b/.env.sample
@@ -2,3 +2,4 @@ RAILS_ENV=production
 SENDGRID_USERNAME=username
 SENDGRID_PASSWORD=password
 GA_TRACKINGID=UA-xxxxxxxx-x
+TWITTER_SECURET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/Gemfile
+++ b/Gemfile
@@ -102,6 +102,8 @@ gem 'everywhere'
 
 # Facebookでログイン
 gem 'omniauth-facebook'
+# Twitterでログイン
+gem 'omniauth-twitter'
 
 # RailsのViewにSlimを利用
 gem "slim-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -222,6 +222,7 @@ GEM
     newrelic_rpm (3.6.8.168)
     nokogiri (1.5.6)
     ntlm-http (0.1.1)
+    oauth (0.4.7)
     oauth2 (0.8.1)
       faraday (~> 0.8)
       httpauth (~> 0.1)
@@ -233,9 +234,15 @@ GEM
       rack
     omniauth-facebook (1.4.1)
       omniauth-oauth2 (~> 1.1.0)
+    omniauth-oauth (1.0.1)
+      oauth
+      omniauth (~> 1.0)
     omniauth-oauth2 (1.1.1)
       oauth2 (~> 0.8.0)
       omniauth (~> 1.0)
+    omniauth-twitter (1.0.1)
+      multi_json (~> 1.3)
+      omniauth-oauth (~> 1.0)
     open_uri_redirections (0.1.4)
     orm_adapter (0.4.0)
     polyglot (0.3.3)
@@ -412,6 +419,7 @@ DEPENDENCIES
   mysql2
   newrelic_rpm
   omniauth-facebook
+  omniauth-twitter
   open_uri_redirections
   private_pub
   rails (= 3.2.14)

--- a/app/assets/stylesheets/users.css.scss
+++ b/app/assets/stylesheets/users.css.scss
@@ -206,16 +206,31 @@ $user_menu_height: 100px;
     padding: 10px 20px;
     font-size: large;
     font-family: $font_gothic;
-    @extend .btn;
-  }
 
-  .facebook a {
+    @extend .btn;
     @extend .btn-primary;
     @include icon(facebook);
+
     &:before {
       margin-right: 15px;
       padding-right: 17px;
       border-right: 1px solid #37d;
+    }
+  }
+
+  .twitter a {
+    padding: 10px 20px;
+    font-size: large;
+    font-family: $font_gothic;
+
+    @extend .btn;
+    @extend .btn-info;
+    @include icon(twitter);
+
+    &:before {
+      margin-right: 15px;
+      padding-right: 17px;
+      border-right: 1px solid #5bc;
     }
   }
 }

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -11,4 +11,16 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       redirect_to new_user_registration_url
     end
   end
+
+  def twitter
+    @user = User.find_for_twitter_oauth(request.env["omniauth.auth"], current_user)
+
+    if @user.persisted?
+      sign_in_and_redirect @user, :event => :authentication
+      set_flash_message(:notice, :success, :kind => "Twitter") if is_navigational_format?
+    else
+      session["devise.twitter_data"] = request.env["omniauth.auth"]
+      redirect_to new_user_registration_url
+    end
+  end
 end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,7 +1,7 @@
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def facebook
     # You need to implement the method below in your model (e.g. app/models/user.rb)
-    @user = User.find_for_facebook_oauth(request.env["omniauth.auth"], current_user)
+    @user = User.find_or_create_for_oauth(request.env["omniauth.auth"], current_user)
 
     if @user.persisted?
       sign_in_and_redirect @user, :event => :authentication #this will throw if @user is not activated
@@ -13,7 +13,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   def twitter
-    @user = User.find_for_twitter_oauth(request.env["omniauth.auth"], current_user)
+    @user = User.find_or_create_for_oauth(request.env["omniauth.auth"], current_user)
 
     if @user.persisted?
       sign_in_and_redirect @user, :event => :authentication

--- a/app/models/concerns/user_omniauth.rb
+++ b/app/models/concerns/user_omniauth.rb
@@ -1,0 +1,47 @@
+module UserOmniauth
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    def find_or_create_for_oauth(auth, signed_in_resource=nil)
+      user = self.where(provider: auth.provider, uid: auth.uid).first
+      user ||= self.create_or_update_for_oauth(auth)
+      user
+    end
+
+    def new_with_session(params, session)
+      super.tap do |user|
+        if data = session["devise.facebook_data"] && session["devise.facebook_data"]["extra"]["raw_info"]
+          user.email = data["email"] if user.email.blank?
+        end
+      end
+    end
+
+    def create_or_update_for_oauth(auth)
+      user = self.where(email: email_for_oauth(auth)).first
+      return self.create_for_oauth(auth) if user.nil?
+      user.update_for_oauth(auth)
+      user
+    end
+
+    def create_for_oauth(auth)
+      self.create(
+        name: auth.extra.raw_info.name,
+        provider: auth.provider,
+        uid: auth.uid,
+        email: email_for_oauth(auth),
+        password: Devise.friendly_token[0, 20]
+      )
+    end
+
+    def email_for_oauth(auth)
+      auth.info.email || "#{auth.uid}@#{auth.provider}.com"
+    end
+  end
+
+  def update_for_oauth(auth)
+    self.update_attributes(
+      provider: auth.provider,
+      uid: auth.uid
+    )
+  end
+end

--- a/config/application.yml
+++ b/config/application.yml
@@ -12,7 +12,6 @@ defaults: &defaults
   minimum_image_height: 16
   allowed_image_aspect: [ 16, 3 ]
   facebook_id: '520109864725351'
-  facebook_key: 'd56427de565d1fbc5d7f2268063c4a30'
   mixi_key: '138755f57dd15996cafaf13177bb1d70114b1760'
   twitter_id: 'TrZTve5b1xwZaxBD8AB3Q'
 

--- a/config/application.yml
+++ b/config/application.yml
@@ -14,6 +14,7 @@ defaults: &defaults
   facebook_id: '520109864725351'
   facebook_key: 'd56427de565d1fbc5d7f2268063c4a30'
   mixi_key: '138755f57dd15996cafaf13177bb1d70114b1760'
+  twitter_id: 'TrZTve5b1xwZaxBD8AB3Q'
 
 development:
   <<: *defaults

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -204,10 +204,15 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', :scope => 'user,public_repo'
-  require 'omniauth-facebook'
+
   # production環境にSSLが用意でき次第、下記行をコメントアウト
   #OpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE unless Rails.env.production?
+
+  require 'omniauth-facebook'
   config.omniauth :facebook, Settings.facebook_id, Settings.facebook_key
+
+  require 'omniauth-twitter'
+  config.omniauth :twitter, Settings.twitter_id, ENV['TWITTER_SECURET']
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -209,7 +209,7 @@ Devise.setup do |config|
   #OpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE unless Rails.env.production?
 
   require 'omniauth-facebook'
-  config.omniauth :facebook, Settings.facebook_id, Settings.facebook_key
+  config.omniauth :facebook, Settings.facebook_id, ENV['FACEBOOK_SECURET']
 
   require 'omniauth-twitter'
   config.omniauth :twitter, Settings.twitter_id, ENV['TWITTER_SECURET']


### PR DESCRIPTION
- 連携処理部分のリファクタリング
- Facebook連携用の秘密鍵削除

上記二点の変更も含む。
以後秘密鍵は再発行したものを利用する（以前のものは利用不可）。
